### PR TITLE
Fix ProGuard Obfuscation Issues

### DIFF
--- a/monetai-sdk/consumer-rules.pro
+++ b/monetai-sdk/consumer-rules.pro
@@ -1,18 +1,8 @@
-# Rules for consumers of the library
-# This file is automatically included in the consumer's build.gradle
+# MonetAI SDK ProGuard rules for consumers
+# This file is automatically included in the consumer's ProGuard configuration
 
-# Keep public API classes
--keep public class com.monetai.sdk.MonetaiSDK { *; }
--keep public class com.monetai.sdk.MonetaiSDKJava { *; }
--keep public class com.monetai.sdk.models.** { *; }
-
-# Keep public methods and fields
--keepclassmembers public class com.monetai.sdk.** {
-    public *;
-}
-
-# Keep enum values
--keepclassmembers enum * {
-    public static **[] values();
-    public static ** valueOf(java.lang.String);
-} 
+# Keep all MonetAI SDK classes, interfaces, and enums to prevent obfuscation issues
+# Since the SDK is open source, there's no security concern with preserving class names
+-keep class com.monetai.sdk.** { *; }
+-keep interface com.monetai.sdk.** { *; }
+-keep enum com.monetai.sdk.** { *; } 

--- a/monetai-sdk/src/main/java/com/monetai/sdk/network/ApiService.kt
+++ b/monetai-sdk/src/main/java/com/monetai/sdk/network/ApiService.kt
@@ -2,7 +2,6 @@ package com.monetai.sdk.network
 
 import com.monetai.sdk.models.*
 import com.monetai.sdk.utils.DateTimeHelper
-import com.google.gson.annotations.SerializedName
 import retrofit2.http.*
 import java.util.Date
 
@@ -56,22 +55,22 @@ interface ApiService {
 
 // Request/Response models
 data class InitializeRequest(
-    @SerializedName("sdkKey") val sdkKey: String,
-    @SerializedName("platform") val platform: String = "android",
-    @SerializedName("version") val version: String
+    val sdkKey: String,
+    val platform: String = "android",
+    val version: String
 )
 
 // AB Test API request/response models
 data class ABTestRequest(
-    @SerializedName("sdkKey") val sdkKey: String,
-    @SerializedName("userId") val userId: String,
-    @SerializedName("platform") val platform: String = "android"
+    val sdkKey: String,
+    val userId: String,
+    val platform: String = "android"
 )
 
 // Matches actual API server response format
 data class ABTestResponse(
-    @SerializedName("group") val group: String?,  // 'baseline' | 'monetai' | 'unknown' | null
-    @SerializedName("campaign") val campaign: CampaignResponse?
+    val group: String?,  // 'baseline' | 'monetai' | 'unknown' | null
+    val campaign: CampaignResponse?
 ) {
     fun toABTestResponse(): com.monetai.sdk.models.ABTestResponse {
         return com.monetai.sdk.models.ABTestResponse(
@@ -83,17 +82,17 @@ data class ABTestResponse(
 
 // Matches actual API server response format (snake_case)
 data class CampaignResponse(
-    @SerializedName("id") val id: Int,
-    @SerializedName("created_at") val created_at: String?,  // ISO 8601 format string
-    @SerializedName("organization_id") val organization_id: Int,
-    @SerializedName("campaign_name") val campaign_name: String,
-    @SerializedName("started_at") val started_at: String?,  // ISO 8601 format string
-    @SerializedName("ended_at") val ended_at: String?,    // ISO 8601 format string
-    @SerializedName("traffic_ratio") val traffic_ratio: Double,
-    @SerializedName("allocation_ratio") val allocation_ratio: Double,
-    @SerializedName("discount_ratio") val discount_ratio: Double,
-    @SerializedName("exposure_time_sec") val exposure_time_sec: Int,
-    @SerializedName("model_accuracy") val model_accuracy: Double?
+    val id: Int,
+    val created_at: String?,  // ISO 8601 format string
+    val organization_id: Int,
+    val campaign_name: String,
+    val started_at: String?,  // ISO 8601 format string
+    val ended_at: String?,    // ISO 8601 format string
+    val traffic_ratio: Double,
+    val allocation_ratio: Double,
+    val discount_ratio: Double,
+    val exposure_time_sec: Int,
+    val model_accuracy: Double?
 ) {
     fun toCampaign(): Campaign {
         return Campaign(
@@ -108,29 +107,29 @@ data class CampaignResponse(
 
 // Matches actual API server response format
 data class InitializeResponse(
-    @SerializedName("organization_id") val organization_id: Int,  // changed to snake_case
-    @SerializedName("platform") val platform: String,
-    @SerializedName("version") val version: String
+    val organization_id: Int,  // changed to snake_case
+    val platform: String,
+    val version: String
 )
 
 data class CreateEventRequest(
-    @SerializedName("sdkKey") val sdkKey: String,
-    @SerializedName("userId") val userId: String,
-    @SerializedName("eventName") val eventName: String,
-    @SerializedName("params") val params: Map<String, Any>?,
-    @SerializedName("createdAt") val createdAt: String,
-    @SerializedName("platform") val platform: String = "android"
+    val sdkKey: String,
+    val userId: String,
+    val eventName: String,
+    val params: Map<String, Any>?,
+    val createdAt: String,
+    val platform: String = "android"
 )
 
 data class PredictRequest(
-    @SerializedName("sdkKey") val sdkKey: String,
-    @SerializedName("userId") val userId: String
+    val sdkKey: String,
+    val userId: String
 )
 
 // Matches actual API server response format
 data class PredictApiResponse(
-    @SerializedName("prediction") val prediction: String?,  // can be null
-    @SerializedName("testGroup") val testGroup: String?    // can be null
+    val prediction: String?,  // can be null
+    val testGroup: String?    // can be null
 ) {
     fun toPredictResponse(): PredictResponse {
         return PredictResponse(
@@ -142,29 +141,29 @@ data class PredictApiResponse(
 
 // Matches actual API server request format (camelCase)
 data class CreateDiscountRequest(
-    @SerializedName("sdkKey") val sdkKey: String,
-    @SerializedName("appUserId") val appUserId: String,
-    @SerializedName("startedAt") val startedAt: String, // ISO 8601 format
-    @SerializedName("endedAt") val endedAt: String    // ISO 8601 format
+    val sdkKey: String,
+    val appUserId: String,
+    val startedAt: String, // ISO 8601 format
+    val endedAt: String    // ISO 8601 format
 )
 
 // Matches actual API server response format
 data class CreateDiscountResponse(
-    @SerializedName("discount") val discount: AppUserDiscountResponse
+    val discount: AppUserDiscountResponse
 )
 
 data class GetDiscountResponse(
-    @SerializedName("discount") val discount: AppUserDiscountResponse?
+    val discount: AppUserDiscountResponse?
 )
 
 // API 서버의 실제 응답 형식에 맞춤 (snake_case)
 data class AppUserDiscountResponse(
-    @SerializedName("id") val id: Int,
-    @SerializedName("started_at") val started_at: String,  // ISO 8601 format string
-    @SerializedName("ended_at") val ended_at: String,    // ISO 8601 format string
-    @SerializedName("app_user_id") val app_user_id: String,
-    @SerializedName("sdk_key") val sdk_key: String,
-    @SerializedName("created_at") val created_at: String   // ISO 8601 format string
+    val id: Int,
+    val started_at: String,  // ISO 8601 format string
+    val ended_at: String,    // ISO 8601 format string
+    val app_user_id: String,
+    val sdk_key: String,
+    val created_at: String   // ISO 8601 format string
 ) {
     fun toAppUserDiscount(): AppUserDiscount {
         // Parse dates using ThreeTenABP library for better ISO 8601 support
@@ -185,21 +184,21 @@ data class AppUserDiscountResponse(
 
 // Actual data structures
 data class TransactionMappingRequest(
-    @SerializedName("purchaseToken") val purchaseToken: String,
-    @SerializedName("packageName") val packageName: String,
-    @SerializedName("userId") val userId: String,
-    @SerializedName("sdkKey") val sdkKey: String
+    val purchaseToken: String,
+    val packageName: String,
+    val userId: String,
+    val sdkKey: String
 )
 
 data class PurchaseHistoryRequest(
-    @SerializedName("packageName") val packageName: String,
-    @SerializedName("userId") val userId: String,
-    @SerializedName("sdkKey") val sdkKey: String,
-    @SerializedName("purchases") val purchases: List<PurchaseItem>
+    val packageName: String,
+    val userId: String,
+    val sdkKey: String,
+    val purchases: List<PurchaseItem>
 )
 
 data class PurchaseItem(
-    @SerializedName("purchaseToken") val purchaseToken: String
+    val purchaseToken: String
 )
 
 class EmptyResponse() 


### PR DESCRIPTION
### Problem
* Customer apps using Monetai SDK with ProGuard/R8 obfuscation enabled were experiencing HTTP 400 errors during API calls.
* The issue occurred because field names in JSON requests were being obfuscated from proper names (e.g., sdkKey, userId) to single letters (e.g., a, b, c), causing the server to reject requests.

### Solution
* Added consumer-rules.pro - Automatically protects Monetai SDK from obfuscation in customer apps
* Zero customer configuration - No ProGuard rules needed in customer apps

### Benefits
* Automatic protection - Works out of the box
* No breaking changes - Backward compatible