### PR TITLE
refactor: rename promotionId to placement across SDK

### DIFF
--- a/examples/sample-java-purchase/src/main/java/com/monetai/sample/kotlin/purchase/Constants.java
+++ b/examples/sample-java-purchase/src/main/java/com/monetai/sample/kotlin/purchase/Constants.java
@@ -7,7 +7,7 @@ public class Constants {
     // MARK: - MonetaiSDK Configuration
     public static final String SDK_KEY = "your-sdk-key-here";
     public static final String USER_ID = "example-user-id-java-purchase";
-    public static final int PROMOTION_ID = 1;
+    public static final String PLACEMENT = "your-placement-here";
     public static final String DEFAULT_PRODUCT_ID = "your-default-product-id-here";
 
     // MARK: - RevenueCat Configuration

--- a/examples/sample-java-purchase/src/main/java/com/monetai/sample/kotlin/purchase/MainActivity.java
+++ b/examples/sample-java-purchase/src/main/java/com/monetai/sample/kotlin/purchase/MainActivity.java
@@ -359,6 +359,7 @@ public class MainActivity extends AppCompatActivity {
                                 matchedPkg.getProduct().getPrice().getAmountMicros() / 1_000_000.0,
                                 basePackage.getProduct().getPrice().getAmountMicros() / 1_000_000.0,
                                 matchedPkg.getProduct().getPrice().getCurrencyCode(),
+                                "promotion",
                                 Constants.PROMOTION_ID,
                                 null
                         )

--- a/examples/sample-java-purchase/src/main/java/com/monetai/sample/kotlin/purchase/MainActivity.java
+++ b/examples/sample-java-purchase/src/main/java/com/monetai/sample/kotlin/purchase/MainActivity.java
@@ -355,11 +355,11 @@ public class MainActivity extends AppCompatActivity {
             if (matchedPkg != null) {
                 monetaiSDK.logViewProductItem(
                         new ViewProductItemParams(
+                                Constants.PLACEMENT,
                                 matchedPkg.getProduct().getId(),
                                 matchedPkg.getProduct().getPrice().getAmountMicros() / 1_000_000.0,
                                 basePackage.getProduct().getPrice().getAmountMicros() / 1_000_000.0,
                                 matchedPkg.getProduct().getPrice().getCurrencyCode(),
-                                Constants.PLACEMENT,
                                 null
                         )
                 );

--- a/examples/sample-java-purchase/src/main/java/com/monetai/sample/kotlin/purchase/MainActivity.java
+++ b/examples/sample-java-purchase/src/main/java/com/monetai/sample/kotlin/purchase/MainActivity.java
@@ -276,7 +276,7 @@ public class MainActivity extends AppCompatActivity {
         isLoading = true;
         updatePredictButtonState();
 
-        monetaiSDK.getOffer(Constants.PROMOTION_ID, (offer, error) -> {
+        monetaiSDK.getOffer(Constants.PLACEMENT, (offer, error) -> {
             runOnUiThread(() -> {
                 if (error != null) {
                     offerResult = "Error: " + error.getMessage();
@@ -359,8 +359,7 @@ public class MainActivity extends AppCompatActivity {
                                 matchedPkg.getProduct().getPrice().getAmountMicros() / 1_000_000.0,
                                 basePackage.getProduct().getPrice().getAmountMicros() / 1_000_000.0,
                                 matchedPkg.getProduct().getPrice().getCurrencyCode(),
-                                "promotion",
-                                Constants.PROMOTION_ID,
+                                Constants.PLACEMENT,
                                 null
                         )
                 );

--- a/examples/sample-kotlin-purchase/src/main/java/com/monetai/sample/kotlin/purchase/Constants.kt
+++ b/examples/sample-kotlin-purchase/src/main/java/com/monetai/sample/kotlin/purchase/Constants.kt
@@ -7,7 +7,7 @@ object Constants {
     // MARK: - MonetaiSDK Configuration
     const val SDK_KEY = "your-sdk-key-here"
     const val USER_ID = "example-user-id-kotlin-purchase"
-    const val PROMOTION_ID = 6
+    const val PLACEMENT = "your-placement-here"
     const val DEFAULT_PRODUCT_ID = "your-default-product-id-here"
 
     // MARK: - RevenueCat Configuration

--- a/examples/sample-kotlin-purchase/src/main/java/com/monetai/sample/kotlin/purchase/MainActivity.kt
+++ b/examples/sample-kotlin-purchase/src/main/java/com/monetai/sample/kotlin/purchase/MainActivity.kt
@@ -270,7 +270,7 @@ class MainActivity : AppCompatActivity() {
         isLoading = true
         updatePredictButtonState()
 
-        monetaiSDK.getOffer(Constants.PROMOTION_ID) { offer, error ->
+        monetaiSDK.getOffer(Constants.PLACEMENT) { offer, error ->
             runOnUiThread {
                 if (error != null) {
                     offerResult = "Error: ${error.message}"
@@ -332,8 +332,7 @@ class MainActivity : AppCompatActivity() {
                         price = pkg.product.price.amountMicros / 1_000_000.0,
                         regularPrice = basePackage.product.price.amountMicros / 1_000_000.0,
                         currencyCode = pkg.product.price.currencyCode,
-                        promotionId = Constants.PROMOTION_ID,
-                        placement = "promotion"
+                        placement = Constants.PLACEMENT
                     )
                 )
             }

--- a/examples/sample-kotlin-purchase/src/main/java/com/monetai/sample/kotlin/purchase/MainActivity.kt
+++ b/examples/sample-kotlin-purchase/src/main/java/com/monetai/sample/kotlin/purchase/MainActivity.kt
@@ -332,7 +332,8 @@ class MainActivity : AppCompatActivity() {
                         price = pkg.product.price.amountMicros / 1_000_000.0,
                         regularPrice = basePackage.product.price.amountMicros / 1_000_000.0,
                         currencyCode = pkg.product.price.currencyCode,
-                        promotionId = Constants.PROMOTION_ID
+                        promotionId = Constants.PROMOTION_ID,
+                        placement = "promotion"
                     )
                 )
             }

--- a/monetai-sdk/src/main/java/com/monetai/sdk/MonetaiSDK.kt
+++ b/monetai-sdk/src/main/java/com/monetai/sdk/MonetaiSDK.kt
@@ -189,16 +189,16 @@ class MonetaiSDK private constructor() {
 
     /**
      * Get dynamic pricing offer for a promotion
-     * @param promotionId Promotion ID
+     * @param placement Placement identifier for the promotion
      * @param completion Completion callback with offer or error
      */
-    fun getOffer(promotionId: Int, completion: ((Offer?, Exception?) -> Unit)? = null) {
+    fun getOffer(placement: String, completion: ((Offer?, Exception?) -> Unit)? = null) {
         internalScope.launch {
             try {
                 val sdkKey = sdkKey ?: throw MonetaiError.NotInitialized
                 val userId = userId ?: throw MonetaiError.NotInitialized
 
-                val offer = ApiRequests.getOffer(sdkKey = sdkKey, userId = userId, promotionId = promotionId)
+                val offer = ApiRequests.getOffer(sdkKey = sdkKey, userId = userId, placement = placement)
 
                 withContext(Dispatchers.Main) {
                     completion?.invoke(offer, null)

--- a/monetai-sdk/src/main/java/com/monetai/sdk/MonetaiSDKJava.kt
+++ b/monetai-sdk/src/main/java/com/monetai/sdk/MonetaiSDKJava.kt
@@ -73,11 +73,11 @@ class MonetaiSDKJava {
 
     /**
      * Get dynamic pricing offer (Java compatible)
-     * @param promotionId Promotion ID
+     * @param placement Placement identifier for the promotion
      * @param completion Callback with offer or error
      */
-    fun getOffer(promotionId: Int, completion: OfferCallback? = null) {
-        MonetaiSDK.shared.getOffer(promotionId) { offer, error ->
+    fun getOffer(placement: String, completion: OfferCallback? = null) {
+        MonetaiSDK.shared.getOffer(placement) { offer, error ->
             completion?.onResult(offer, error)
         }
     }

--- a/monetai-sdk/src/main/java/com/monetai/sdk/models/ViewProductItemParams.kt
+++ b/monetai-sdk/src/main/java/com/monetai/sdk/models/ViewProductItemParams.kt
@@ -5,6 +5,7 @@ data class ViewProductItemParams(
     val price: Double,
     val regularPrice: Double,
     val currencyCode: String,
-    val promotionId: Int,
+    val promotionId: Int? = null,
+    val source: String? = null,
     val month: Int? = null
 )

--- a/monetai-sdk/src/main/java/com/monetai/sdk/models/ViewProductItemParams.kt
+++ b/monetai-sdk/src/main/java/com/monetai/sdk/models/ViewProductItemParams.kt
@@ -1,10 +1,10 @@
 package com.monetai.sdk.models
 
 data class ViewProductItemParams(
+    val placement: String,
     val productId: String,
     val price: Double,
     val regularPrice: Double,
     val currencyCode: String,
-    val placement: String,
     val month: Int? = null
 )

--- a/monetai-sdk/src/main/java/com/monetai/sdk/models/ViewProductItemParams.kt
+++ b/monetai-sdk/src/main/java/com/monetai/sdk/models/ViewProductItemParams.kt
@@ -6,6 +6,5 @@ data class ViewProductItemParams(
     val regularPrice: Double,
     val currencyCode: String,
     val placement: String,
-    val promotionId: Int? = null,
     val month: Int? = null
 )

--- a/monetai-sdk/src/main/java/com/monetai/sdk/models/ViewProductItemParams.kt
+++ b/monetai-sdk/src/main/java/com/monetai/sdk/models/ViewProductItemParams.kt
@@ -5,7 +5,7 @@ data class ViewProductItemParams(
     val price: Double,
     val regularPrice: Double,
     val currencyCode: String,
+    val placement: String,
     val promotionId: Int? = null,
-    val source: String? = null,
     val month: Int? = null
 )

--- a/monetai-sdk/src/main/java/com/monetai/sdk/network/ApiRequests.kt
+++ b/monetai-sdk/src/main/java/com/monetai/sdk/network/ApiRequests.kt
@@ -111,11 +111,11 @@ object ApiRequests {
         val request = ViewProductItemRequest(
             sdkKey = sdkKey,
             userId = userId,
+            placement = params.placement,
             productId = params.productId,
             price = params.price,
             regularPrice = params.regularPrice,
             currencyCode = params.currencyCode,
-            placement = params.placement,
             month = params.month,
             createdAt = createdAt,
             platform = "android"

--- a/monetai-sdk/src/main/java/com/monetai/sdk/network/ApiRequests.kt
+++ b/monetai-sdk/src/main/java/com/monetai/sdk/network/ApiRequests.kt
@@ -116,6 +116,7 @@ object ApiRequests {
             regularPrice = params.regularPrice,
             currencyCode = params.currencyCode,
             promotionId = params.promotionId,
+            source = params.source,
             month = params.month,
             createdAt = createdAt,
             platform = "android"

--- a/monetai-sdk/src/main/java/com/monetai/sdk/network/ApiRequests.kt
+++ b/monetai-sdk/src/main/java/com/monetai/sdk/network/ApiRequests.kt
@@ -115,8 +115,8 @@ object ApiRequests {
             price = params.price,
             regularPrice = params.regularPrice,
             currencyCode = params.currencyCode,
+            placement = params.placement,
             promotionId = params.promotionId,
-            source = params.source,
             month = params.month,
             createdAt = createdAt,
             platform = "android"

--- a/monetai-sdk/src/main/java/com/monetai/sdk/network/ApiRequests.kt
+++ b/monetai-sdk/src/main/java/com/monetai/sdk/network/ApiRequests.kt
@@ -69,11 +69,11 @@ object ApiRequests {
     /**
      * Get offer for a promotion
      */
-    suspend fun getOffer(sdkKey: String, userId: String, promotionId: Int): Offer? {
+    suspend fun getOffer(sdkKey: String, userId: String, placement: String): Offer? {
         val request = GetOfferRequest(
             sdkKey = sdkKey,
             userId = userId,
-            promotionId = promotionId,
+            placement = placement,
             platform = "android"
         )
 
@@ -116,7 +116,6 @@ object ApiRequests {
             regularPrice = params.regularPrice,
             currencyCode = params.currencyCode,
             placement = params.placement,
-            promotionId = params.promotionId,
             month = params.month,
             createdAt = createdAt,
             platform = "android"

--- a/monetai-sdk/src/main/java/com/monetai/sdk/network/ApiService.kt
+++ b/monetai-sdk/src/main/java/com/monetai/sdk/network/ApiService.kt
@@ -68,7 +68,7 @@ data class CreateEventRequest(
 data class GetOfferRequest(
     val sdkKey: String,
     val userId: String,
-    val promotionId: Int,
+    val placement: String,
     val platform: String = "android"
 )
 
@@ -94,7 +94,6 @@ data class ViewProductItemRequest(
     val regularPrice: Double,
     val currencyCode: String,
     val placement: String,
-    val promotionId: Int?,
     val month: Int?,
     val createdAt: String,
     val platform: String = "android"

--- a/monetai-sdk/src/main/java/com/monetai/sdk/network/ApiService.kt
+++ b/monetai-sdk/src/main/java/com/monetai/sdk/network/ApiService.kt
@@ -93,7 +93,8 @@ data class ViewProductItemRequest(
     val price: Double,
     val regularPrice: Double,
     val currencyCode: String,
-    val promotionId: Int,
+    val promotionId: Int?,
+    val source: String?,
     val month: Int?,
     val createdAt: String,
     val platform: String = "android"

--- a/monetai-sdk/src/main/java/com/monetai/sdk/network/ApiService.kt
+++ b/monetai-sdk/src/main/java/com/monetai/sdk/network/ApiService.kt
@@ -89,11 +89,11 @@ data class OfferProductResponse(
 data class ViewProductItemRequest(
     val sdkKey: String,
     val userId: String,
+    val placement: String,
     val productId: String,
     val price: Double,
     val regularPrice: Double,
     val currencyCode: String,
-    val placement: String,
     val month: Int?,
     val createdAt: String,
     val platform: String = "android"

--- a/monetai-sdk/src/main/java/com/monetai/sdk/network/ApiService.kt
+++ b/monetai-sdk/src/main/java/com/monetai/sdk/network/ApiService.kt
@@ -93,8 +93,8 @@ data class ViewProductItemRequest(
     val price: Double,
     val regularPrice: Double,
     val currencyCode: String,
+    val placement: String,
     val promotionId: Int?,
-    val source: String?,
     val month: Int?,
     val createdAt: String,
     val platform: String = "android"


### PR DESCRIPTION
## Summary
- Renamed `promotionId` (Int) to `placement` (String) in `getOffer` and `ViewProductItemParams` across the SDK, Java wrapper, API requests, and API service models
- Made `placement` the first parameter in `ViewProductItemParams` for better API ergonomics
- Updated Java and Kotlin example apps to use the new `placement` parameter

## Test plan
- [ ] Verify `getOffer` works with string-based `placement` parameter
- [ ] Verify `logViewProductItem` correctly sends `placement` field
- [ ] Build and run example apps (Kotlin & Java) to confirm no compilation errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)